### PR TITLE
Add ConnectionLostHandler args to mqtt.ClientOptions.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -84,7 +84,7 @@ func connectionHandler(c *DeviceClient) {
 				}
 				c.dbg.printf("Trying to reconnect (%d ms)\n", c.reconnectPeriod/time.Millisecond)
 				if c.opt.OnConnectionLost != nil {
-					c.opt.OnConnectionLost(c.opt)
+					c.opt.OnConnectionLost(c.mqttOpt)
 				}
 
 				go func() {

--- a/connection.go
+++ b/connection.go
@@ -84,7 +84,7 @@ func connectionHandler(c *DeviceClient) {
 				}
 				c.dbg.printf("Trying to reconnect (%d ms)\n", c.reconnectPeriod/time.Millisecond)
 				if c.opt.OnConnectionLost != nil {
-					c.opt.OnConnectionLost(c.mqttOpt)
+					c.opt.OnConnectionLost(c.opt, c.mqttOpt)
 				}
 
 				go func() {

--- a/connection.go
+++ b/connection.go
@@ -83,10 +83,6 @@ func connectionHandler(c *DeviceClient) {
 					c.reconnectPeriod = c.opt.MaximumReconnectTime
 				}
 				c.dbg.printf("Trying to reconnect (%d ms)\n", c.reconnectPeriod/time.Millisecond)
-				if c.opt.OnConnectionLost != nil {
-					c.opt.OnConnectionLost(c.opt, c.mqttOpt)
-				}
-
 				go func() {
 					time.Sleep(c.reconnectPeriod)
 					c.stateUpdateCh <- reconnecting

--- a/device.go
+++ b/device.go
@@ -87,6 +87,10 @@ func New(opt *Options) *DeviceClient {
 
 	connectionLost := func(client mqtt.Client, err error) {
 		d.dbg.printf("Connection lost (%s)\n", err.Error())
+		if d.opt.OnConnectionLost != nil {
+			d.opt.OnConnectionLost(d.opt, d.mqttOpt, err)
+		}
+
 		d.stateUpdateCh <- inactive
 	}
 	onConnect := func(client mqtt.Client) {

--- a/options.go
+++ b/options.go
@@ -27,7 +27,7 @@ type TopicPayload struct {
 }
 
 // ConnectionLostHandler is the function type for connection lost callback.
-type ConnectionLostHandler func(*Options, *mqtt.ClientOptions)
+type ConnectionLostHandler func(*Options, *mqtt.ClientOptions, error)
 
 // Options stores configuration of the MQTT connection.
 type Options struct {

--- a/options.go
+++ b/options.go
@@ -16,6 +16,8 @@ package awsiotdev
 
 import (
 	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
 // TopicPayload stores a pair of topic name and payload string.
@@ -25,7 +27,7 @@ type TopicPayload struct {
 }
 
 // ConnectionLostHandler is the function type for connection lost callback.
-type ConnectionLostHandler func(*Options)
+type ConnectionLostHandler func(*mqtt.ClientOptions)
 
 // Options stores configuration of the MQTT connection.
 type Options struct {

--- a/options.go
+++ b/options.go
@@ -27,7 +27,7 @@ type TopicPayload struct {
 }
 
 // ConnectionLostHandler is the function type for connection lost callback.
-type ConnectionLostHandler func(*mqtt.ClientOptions)
+type ConnectionLostHandler func(*Options, *mqtt.ClientOptions)
 
 // Options stores configuration of the MQTT connection.
 type Options struct {

--- a/sample/main.go
+++ b/sample/main.go
@@ -70,7 +70,7 @@ func main() {
 		OfflineQueueMaxSize:      100,
 		OfflineQueueDropBehavior: "oldest",
 		AutoResubscribe:          true,
-		OnConnectionLost: func(opt *awsiot.Options) {
+		OnConnectionLost: func(mqttOpt *mqtt.ClientOptions) {
 			fmt.Printf("Connection lost handler function called\n")
 		},
 	}

--- a/sample/main.go
+++ b/sample/main.go
@@ -70,7 +70,7 @@ func main() {
 		OfflineQueueMaxSize:      100,
 		OfflineQueueDropBehavior: "oldest",
 		AutoResubscribe:          true,
-		OnConnectionLost: func(mqttOpt *mqtt.ClientOptions) {
+		OnConnectionLost: func(opt *awsiot.Options, mqttOpt *mqtt.ClientOptions) {
 			fmt.Printf("Connection lost handler function called\n")
 		},
 	}

--- a/sample/main.go
+++ b/sample/main.go
@@ -70,7 +70,7 @@ func main() {
 		OfflineQueueMaxSize:      100,
 		OfflineQueueDropBehavior: "oldest",
 		AutoResubscribe:          true,
-		OnConnectionLost: func(opt *awsiot.Options, mqttOpt *mqtt.ClientOptions) {
+		OnConnectionLost: func(opt *awsiot.Options, mqttOpt *mqtt.ClientOptions, err error) {
 			fmt.Printf("Connection lost handler function called\n")
 		},
 	}


### PR DESCRIPTION
`awsiotdev.Options` is not used in the reconnect process.
 So I added it to receive `mqtt.ClientOptions` too.