### PR TITLE
Add test cases of loader.go

### DIFF
--- a/awsiotprotocol/loader_test.go
+++ b/awsiotprotocol/loader_test.go
@@ -47,8 +47,7 @@ func TestByURLFailure(t *testing.T) {
 		_, err := ByURL(v.input)
 		if err == nil {
 			t.Errorf("awsiotprotocol.ByURL should fail with invalid input.\ninput: %#v", v.input)
-		}
-		if !strings.Contains(err.Error(), v.expectedErrorMessage) {
+		} else if !strings.Contains(err.Error(), v.expectedErrorMessage) {
 			t.Errorf("awsiotprotocol.ByURL should fail with error message which contains the following:\ninput: %#v\nexpected error message: %#v\nactual error message: %#v", v.input, v.expectedErrorMessage, err.Error())
 		}
 	}

--- a/awsiotprotocol/loader_test.go
+++ b/awsiotprotocol/loader_test.go
@@ -15,9 +15,8 @@
 package awsiotprotocol
 
 import (
+	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestByURL(t *testing.T) {
@@ -37,11 +36,20 @@ func TestByURL(t *testing.T) {
 }
 
 func TestByURLFailure(t *testing.T) {
-	_, err := ByURL("@@://@@@/@@.@@@")
-	assert.NotNil(t, err, "Should return error when a malformed url is given")
-	assert.Contains(t, err.Error(), "parse @@://@@@/@@.@@@: ")
-
-	_, err = ByURL("https://non-supported.protocol.com")
-	assert.NotNil(t, err, "Should return error when the protocol is not supported")
-	assert.Equal(t, err.Error(), "Protocol \"https\" is not supported")
+	testcase := []struct {
+		input                string
+		expectedErrorMessage string
+	}{
+		{input: "@@://@@@/@@.@@@", expectedErrorMessage: "parse @@://@@@/@@.@@@: "},
+		{input: "https://non-supported.protocol.com", expectedErrorMessage: "Protocol \"https\" is not supported"},
+	}
+	for _, v := range testcase {
+		_, err := ByURL(v.input)
+		if err == nil {
+			t.Errorf("awsiotprotocol.ByURL should fail with invalid input.\ninput: %#v", v.input)
+		}
+		if !strings.Contains(err.Error(), v.expectedErrorMessage) {
+			t.Errorf("awsiotprotocol.ByURL should fail with error message which contains the following:\ninput: %#v\nexpected error message: %#v\nactual error message: %#v", v.input, v.expectedErrorMessage, err.Error())
+		}
+	}
 }

--- a/awsiotprotocol/loader_test.go
+++ b/awsiotprotocol/loader_test.go
@@ -16,6 +16,8 @@ package awsiotprotocol
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestByURL(t *testing.T) {
@@ -32,4 +34,14 @@ func TestByURL(t *testing.T) {
 			t.Errorf("awsiotprotocol.ByURL failed.\ninput: %#v\nactual: %#v\nexpected: %#v\n", v.input, actual, v.expected)
 		}
 	}
+}
+
+func TestByURLFailure(t *testing.T) {
+	_, err := ByURL("@@://@@@/@@.@@@")
+	assert.NotNil(t, err, "Should return error when a malformed url is given")
+	assert.Contains(t, err.Error(), "parse @@://@@@/@@.@@@: ")
+
+	_, err = ByURL("https://non-supported.protocol.com")
+	assert.NotNil(t, err, "Should return error when the protocol is not supported")
+	assert.Equal(t, err.Error(), "Protocol \"https\" is not supported")
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.1.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/stretchr/testify v1.2.2
 	golang.org/x/net v0.0.0-20181102091132-c10e9556a7bc // indirect
 	golang.org/x/text v0.3.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.1.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.2.2 // indirect
 	golang.org/x/net v0.0.0-20181102091132-c10e9556a7bc // indirect
 	golang.org/x/text v0.3.0 // indirect
 )


### PR DESCRIPTION
This PR adds the test cases for error situations of `awsiotprotocol/loader`. This should improve the coverage score.