### PR TITLE
Add PublishSimple method

### DIFF
--- a/v2/device.go
+++ b/v2/device.go
@@ -145,6 +145,12 @@ func (s *DeviceClient) Publish(topic string, qos byte, retained bool, payload in
 	return &mqtt.DummyToken{}
 }
 
+// PublishSimple publishes a message without queueing to the internal queue.
+// The messages will be lost when they are published offline.
+func (s *DeviceClient) PublishSimple(topic string, qos byte, retained bool, payload interface{}) mqtt.Token {
+	return s.cli.Publish(topic, qos, retained, payload)
+}
+
 // Subscribe requests a new subscription for the specified topic.
 // Currently, qos argument is ignored and one specified in the options is used.
 func (s *DeviceClient) Subscribe(topic string, qos byte, cb mqtt.MessageHandler) mqtt.Token {


### PR DESCRIPTION
This PR adds `PublishSimple` method to DeviceClient, which skips queueing to the internal queue when the publishing failed, and directly publishes to AWS IoT. This method would be useful for topics which have high frequency and is not useful to store the past data.