### PR TITLE
Add go v1.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - "1.11"
   - "1.12"
+  - "1.13"
   - master
 
 env:

--- a/internal/awsiotprotocol/loader_test.go
+++ b/internal/awsiotprotocol/loader_test.go
@@ -15,6 +15,7 @@
 package awsiotprotocol
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -36,19 +37,23 @@ func TestByURL(t *testing.T) {
 }
 
 func TestByURLFailure(t *testing.T) {
-	testcase := []struct {
-		input                string
-		expectedErrorMessage string
-	}{
-		{input: "@@://@@@/@@.@@@", expectedErrorMessage: "parse @@://@@@/@@.@@@: "},
-		{input: "https://non-supported.protocol.com", expectedErrorMessage: "Protocol \"https\" is not supported"},
-	}
-	for _, v := range testcase {
-		_, err := ByURL(v.input)
+	t.Run("Un parsed url", func(t *testing.T) {
+		input := "@@://@@@/@@.@@@"
+		_, err := ByURL(input)
 		if err == nil {
-			t.Errorf("awsiotprotocol.ByURL should fail with invalid input.\ninput: %#v", v.input)
-		} else if !strings.Contains(err.Error(), v.expectedErrorMessage) {
-			t.Errorf("awsiotprotocol.ByURL should fail with error message which contains the following:\ninput: %#v\nexpected error message: %#v\nactual error message: %#v", v.input, v.expectedErrorMessage, err.Error())
+			t.Errorf("awsiotprotocol.ByURL should fail with invalid input.\ninput: %#v", input)
+		} else if _, ok := err.(*url.Error); !ok {
+			t.Errorf("awsiotprotocol.ByURL should fail with url.Error type:\ninput: %#v\nactual error: %#v", input, err)
 		}
-	}
+	})
+	t.Run("No supported protocol", func(t *testing.T) {
+		input := "https://non-supported.protocol.com"
+		expectedErrorMessage := "Protocol \"https\" is not supported"
+		_, err := ByURL(input)
+		if err == nil {
+			t.Errorf("awsiotprotocol.ByURL should fail with invalid input.\ninput: %#v", input)
+		} else if !strings.Contains(err.Error(), expectedErrorMessage) {
+			t.Errorf("awsiotprotocol.ByURL should fail with error message which contains the following:\ninput: %#v\nexpected error message: %#v\nactual error message: %#v", input, expectedErrorMessage, err.Error())
+		}
+	})
 }

--- a/internal/awsiotprotocol/loader_test.go
+++ b/internal/awsiotprotocol/loader_test.go
@@ -37,7 +37,7 @@ func TestByURL(t *testing.T) {
 }
 
 func TestByURLFailure(t *testing.T) {
-	t.Run("Un parsed url", func(t *testing.T) {
+	t.Run("Cannot parse url", func(t *testing.T) {
 		input := "@@://@@@/@@.@@@"
 		_, err := ByURL(input)
 		if err == nil {
@@ -46,7 +46,7 @@ func TestByURLFailure(t *testing.T) {
 			t.Errorf("awsiotprotocol.ByURL should fail with url.Error type:\ninput: %#v\nactual error: %#v", input, err)
 		}
 	})
-	t.Run("No supported protocol", func(t *testing.T) {
+	t.Run("Un supported protocol", func(t *testing.T) {
 		input := "https://non-supported.protocol.com"
 		expectedErrorMessage := "Protocol \"https\" is not supported"
 		_, err := ByURL(input)

--- a/internal/awsiotprotocol/loader_test.go
+++ b/internal/awsiotprotocol/loader_test.go
@@ -37,7 +37,7 @@ func TestByURL(t *testing.T) {
 }
 
 func TestByURLFailure(t *testing.T) {
-	t.Run("Cannot parse url", func(t *testing.T) {
+	t.Run("Invalid URL", func(t *testing.T) {
 		input := "@@://@@@/@@.@@@"
 		_, err := ByURL(input)
 		if err == nil {
@@ -46,7 +46,7 @@ func TestByURLFailure(t *testing.T) {
 			t.Errorf("awsiotprotocol.ByURL should fail with url.Error type:\ninput: %#v\nactual error: %#v", input, err)
 		}
 	})
-	t.Run("Un supported protocol", func(t *testing.T) {
+	t.Run("Unsupported protocol", func(t *testing.T) {
 		input := "https://non-supported.protocol.com"
 		expectedErrorMessage := "Protocol \"https\" is not supported"
 		_, err := ByURL(input)


### PR DESCRIPTION
Add golang version `1.13` support to `.travis.yaml`
And fix [TestByURLFailure](https://travis-ci.com/seqsense/aws-iot-device-sdk-go/jobs/262420824) because [net/url package updated](https://github.com/golang/go/commit/64cfe9fe22113cd6bc05a2c5d0cbe872b1b57860#diff-6c2d018290e298803c0c9419d8739885)