### PR TITLE
shadow: avoid document mutation

### DIFF
--- a/shadow/copy.go
+++ b/shadow/copy.go
@@ -48,6 +48,9 @@ func cloneStateSlice(s []interface{}) []interface{} {
 
 // clone returns deepcopy of the document.
 func (s *ThingDocument) clone() *ThingDocument {
+	if s == nil {
+		return nil
+	}
 	c := *s
 	c.State.Desired = cloneState(s.State.Desired)
 	c.State.Reported = cloneState(s.State.Reported)

--- a/shadow/copy.go
+++ b/shadow/copy.go
@@ -1,0 +1,42 @@
+package shadow
+
+// cloneState creates deepcopy of thing state.
+func cloneState(s map[string]interface{}) map[string]interface{} {
+	c := map[string]interface{}{}
+	for k, v := range s {
+		switch vv := v.(type) {
+		case map[string]interface{}:
+			c[k] = cloneState(vv)
+		case []interface{}:
+			c[k] = cloneStateSlice(vv)
+		default:
+			c[k] = vv
+		}
+	}
+	return c
+}
+
+// cloneStateSlice creates deepcopy of thing state slice.
+func cloneStateSlice(s []interface{}) []interface{} {
+	c := []interface{}{}
+	for _, v := range s {
+		switch vv := v.(type) {
+		case map[string]interface{}:
+			c = append(c, cloneState(vv))
+		case []interface{}:
+			c = append(c, cloneStateSlice(vv))
+		default:
+			c = append(c, vv)
+		}
+	}
+	return c
+}
+
+// clone returns deepcopy of the document.
+func (s *ThingDocument) clone() *ThingDocument {
+	c := *s
+	c.State.Desired = cloneState(s.State.Desired)
+	c.State.Reported = cloneState(s.State.Reported)
+	c.State.Delta = cloneState(s.State.Delta)
+	return &c
+}

--- a/shadow/copy.go
+++ b/shadow/copy.go
@@ -1,3 +1,17 @@
+// Copyright 2020 SEQSENSE, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package shadow
 
 // cloneState creates deepcopy of thing state.

--- a/shadow/copy_test.go
+++ b/shadow/copy_test.go
@@ -1,0 +1,103 @@
+// Copyright 2020 SEQSENSE, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shadow
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestClone(t *testing.T) {
+	testCases := map[string]struct {
+		doc    *ThingDocument
+		mutate func(*ThingDocument)
+	}{
+		"Base": {
+			doc: &ThingDocument{Version: 10},
+			mutate: func(doc *ThingDocument) {
+				doc.Version = 1
+			},
+		},
+		"Map": {
+			doc: &ThingDocument{
+				State: ThingState{
+					Desired: map[string]interface{}{
+						"key": "value",
+					},
+				},
+			},
+			mutate: func(doc *ThingDocument) {
+				doc.State.Desired["key"] = "value2"
+			},
+		},
+		"MapInMap": {
+			doc: &ThingDocument{
+				State: ThingState{
+					Desired: map[string]interface{}{
+						"key": map[string]interface{}{
+							"childKey": "value",
+						},
+					},
+				},
+			},
+			mutate: func(doc *ThingDocument) {
+				doc.State.Desired["key"].(map[string]interface{})["childKey"] = "value2"
+			},
+		},
+		"SliceInMap": {
+			doc: &ThingDocument{
+				State: ThingState{
+					Desired: map[string]interface{}{
+						"key": []interface{}{
+							"value1",
+							"value2",
+						},
+					},
+				},
+			},
+			mutate: func(doc *ThingDocument) {
+				doc.State.Desired["key"].([]interface{})[0] = "value1b"
+			},
+		},
+		"Nil": {
+			doc:    nil,
+			mutate: func(doc *ThingDocument) {},
+		},
+	}
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			originalJson, err := json.Marshal(testCase.doc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cloned := testCase.doc.clone()
+			testCase.mutate(cloned)
+
+			resultJson, err := json.Marshal(testCase.doc)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(originalJson, resultJson) {
+				t.Errorf(
+					"Original document is mutated by updating cloned one\nexpected: %s\ngot: %s",
+					originalJson, resultJson,
+				)
+			}
+		})
+	}
+}

--- a/shadow/copy_test.go
+++ b/shadow/copy_test.go
@@ -80,22 +80,22 @@ func TestClone(t *testing.T) {
 	for name, testCase := range testCases {
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
-			originalJson, err := json.Marshal(testCase.doc)
+			originalJSON, err := json.Marshal(testCase.doc)
 			if err != nil {
 				t.Fatal(err)
 			}
 			cloned := testCase.doc.clone()
 			testCase.mutate(cloned)
 
-			resultJson, err := json.Marshal(testCase.doc)
+			resultJSON, err := json.Marshal(testCase.doc)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(originalJson, resultJson) {
+			if !bytes.Equal(originalJSON, resultJSON) {
 				t.Errorf(
 					"Original document is mutated by updating cloned one\nexpected: %s\ngot: %s",
-					originalJson, resultJson,
+					originalJSON, resultJSON,
 				)
 			}
 		})


### PR DESCRIPTION
Deepcopy before returning documents.
Use mutex on update.

~after #125~