### PR TITLE
ci: update codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        # Allow decreasing 2% of total coverage to avoid noise.
+        threshold: 2%
+    patch:
+      default:
+        target: 50%
+        only_pulls: true
 ignore:
   - "sample"


### PR DESCRIPTION
Avoid coverage status failure due to noise.
Disable patch coverage report on master branch.