### PR TITLE
Support Go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: go
 
 go:
-  - "1.12"
   - "1.13"
   - "1.14"
+  - "1.15"
   - master
 
 env:
   global:
-    - REVIEW_DOG_ON=1.14
+    - REVIEW_DOG_ON=1.15
     - REVIEW_DOG_VERSION=0.9.17
-    - GO111MODULE=on
 
 branches:
   only:

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	google.golang.org/protobuf v1.25.0
 )
 
-go 1.13
+go 1.15


### PR DESCRIPTION
and drop Go 1.12 as it's no longer officially supported. (Go 1.13 as well, should it be dropped?)