### PR TITLE
Update at-wat/mqtt-go to v0.12.0

### DIFF
--- a/awsiotdev_test.go
+++ b/awsiotdev_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNew(t *testing.T) {
 	const name = "thing_name1"
-	d, err := New(name, mqtt.DialerFunc(func() (mqtt.ClientCloser, error) {
+	d, err := New(name, mqtt.DialerFunc(func() (*mqtt.BaseClient, error) {
 		return &mqtt.BaseClient{}, nil
 	}))
 	if err != nil {

--- a/dialer.go
+++ b/dialer.go
@@ -40,7 +40,7 @@ func NewPresignDialer(sess client.ConfigProvider, endpoint string, opts ...mqtt.
 	}, nil
 }
 
-func (d *presignDialer) Dial() (mqtt.ClientCloser, error) {
+func (d *presignDialer) Dial() (*mqtt.BaseClient, error) {
 	url, err := d.signer.PresignWssNow(d.endpoint)
 	if err != nil {
 		return nil, ioterr.New(err, "presigning wss URL")

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/seqsense/aws-iot-device-sdk-go/v4
 
 require (
-	github.com/at-wat/mqtt-go v0.11.4
+	github.com/at-wat/mqtt-go v0.12.0
 	github.com/aws/aws-sdk-go v1.37.6
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/at-wat/mqtt-go v0.11.4 h1:tVv+BhsT1SbbdZ9QuBPnPb4iVy7V6hYMenAatQ2z8xY=
-github.com/at-wat/mqtt-go v0.11.4/go.mod h1:NWhjSXyT2oraZmmgomhft0vSLL2DQNrSsRZmG1odl1s=
+github.com/at-wat/mqtt-go v0.12.0 h1:FMNOx7ERFt3N8kx/LxSSfGMk5BnlB5cwxjRqrYV6+7A=
+github.com/at-wat/mqtt-go v0.12.0/go.mod h1:b4QTk+HgoReGBw9R652AH0Kqc2OvkLSD7lOgyxWgeQE=
 github.com/aws/aws-sdk-go v1.37.6 h1:SWYjRvyZw6DJc3pkZfRWVRD/5wiTDuwOkyb89AAkEBY=
 github.com/aws/aws-sdk-go v1.37.6/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -54,8 +54,6 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20201031054903-ff519b6c9102 h1:42cLlJJdEh+ySyeUUbEQ5bsTiq8voBeTuweGVkY6Puw=
-golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -86,7 +86,7 @@ func New(ctx context.Context, cli awsiotdev.Device) (Jobs, error) {
 		}
 	}
 
-	err := cli.Subscribe(ctx,
+	_, err := cli.Subscribe(ctx,
 		mqtt.Subscription{Topic: j.topic("notify"), QoS: mqtt.QoS1},
 		mqtt.Subscription{Topic: j.topic("get/#"), QoS: mqtt.QoS1},
 		mqtt.Subscription{Topic: j.topic("+/get/#"), QoS: mqtt.QoS1},

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -46,8 +46,8 @@ func TestNew(t *testing.T) {
 		defer cancel()
 
 		cli := &mockDevice{&mockmqtt.Client{
-			SubscribeFn: func(ctx context.Context, subs ...mqtt.Subscription) error {
-				return errDummy
+			SubscribeFn: func(ctx context.Context, subs ...mqtt.Subscription) ([]mqtt.Subscription, error) {
+				return nil, errDummy
 			},
 		}}
 		_, err := New(ctx, cli)

--- a/shadow/shadow.go
+++ b/shadow/shadow.go
@@ -203,7 +203,7 @@ func New(ctx context.Context, cli awsiotdev.Device, opt ...Option) (Shadow, erro
 		}
 	}
 
-	err := cli.Subscribe(ctx,
+	_, err := cli.Subscribe(ctx,
 		mqtt.Subscription{Topic: s.topic("update/delta"), QoS: mqtt.QoS1},
 		mqtt.Subscription{Topic: s.topic("update/accepted"), QoS: mqtt.QoS1},
 		mqtt.Subscription{Topic: s.topic("update/rejected"), QoS: mqtt.QoS1},

--- a/shadow/shadow_test.go
+++ b/shadow/shadow_test.go
@@ -44,8 +44,8 @@ func TestNew(t *testing.T) {
 		defer cancel()
 
 		cli := &mockDevice{&mockmqtt.Client{
-			SubscribeFn: func(ctx context.Context, subs ...mqtt.Subscription) error {
-				return errDummy
+			SubscribeFn: func(ctx context.Context, subs ...mqtt.Subscription) ([]mqtt.Subscription, error) {
+				return nil, errDummy
 			},
 		}}
 		_, err := New(ctx, cli)

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -79,7 +79,7 @@ func New(ctx context.Context, cli awsiotdev.Device, dialer map[string]Dialer, op
 		return nil, ioterr.New(err, "registering message handler")
 	}
 
-	err := cli.Subscribe(ctx,
+	_, err := cli.Subscribe(ctx,
 		mqtt.Subscription{Topic: t.opts.TopicFunc("notify"), QoS: mqtt.QoS1},
 	)
 	if err != nil {

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -59,8 +59,8 @@ func TestNew(t *testing.T) {
 		defer cancel()
 
 		cli := &mockDevice{&mockmqtt.Client{
-			SubscribeFn: func(ctx context.Context, subs ...mqtt.Subscription) error {
-				return errDummy
+			SubscribeFn: func(ctx context.Context, subs ...mqtt.Subscription) ([]mqtt.Subscription, error) {
+				return nil, errDummy
 			},
 		}}
 		_, err := New(ctx, cli, map[string]Dialer{})


### PR DESCRIPTION
Details of the API changes: https://github.com/at-wat/mqtt-go/releases/tag/v0.12.0