### PR TITLE
shadow: Avoid panic on updateAccepted

### DIFF
--- a/shadow/shadow.go
+++ b/shadow/shadow.go
@@ -99,7 +99,7 @@ func (s *shadow) handleResponse(r interface{}) {
 }
 
 func (s *shadow) getAccepted(msg *mqtt.Message) {
-	doc := &ThingDocument{}
+	doc := newThingDocument()
 	if err := json.Unmarshal(msg.Payload, doc); err != nil {
 		s.handleError(ioterr.New(err, "unmarshaling thing document"))
 		return
@@ -178,18 +178,7 @@ func New(ctx context.Context, cli awsiotdev.Device, opt ...Option) (Shadow, erro
 		cli:       cli,
 		thingName: cli.ThingName(),
 		opts:      &opts,
-		doc: &ThingDocument{
-			State: ThingState{
-				Desired:  NestedState{},
-				Reported: NestedState{},
-				Delta:    NestedState{},
-			},
-			Metadata: ThingStateMetadata{
-				Desired:  NestedMetadata{},
-				Reported: NestedMetadata{},
-				Delta:    NestedMetadata{},
-			},
-		},
+		doc:       newThingDocument(),
 
 		chResps: make(map[string]chan interface{}),
 	}

--- a/shadow/shadow_test.go
+++ b/shadow/shadow_test.go
@@ -147,6 +147,9 @@ func TestHandlers(t *testing.T) {
 					State: ThingState{
 						Desired: NestedState{"key": "value_init"},
 					},
+					Metadata: ThingStateMetadata{
+						Delta: NestedMetadata{},
+					},
 					Version:   2,
 					Timestamp: 12345,
 				},
@@ -159,8 +162,14 @@ func TestHandlers(t *testing.T) {
 			}
 			expectedDoc := &ThingDocument{
 				State: ThingState{
-					Desired: NestedState{"key2": "value2"},
-					Delta:   NestedState{"key2": "value2"},
+					Desired:  NestedState{"key2": "value2"},
+					Reported: NestedState{},
+					Delta:    NestedState{"key2": "value2"},
+				},
+				Metadata: ThingStateMetadata{
+					Desired:  NestedMetadata{},
+					Reported: NestedMetadata{},
+					Delta:    NestedMetadata{},
 				},
 				Version:   3,
 				Timestamp: 12346,

--- a/shadow/state.go
+++ b/shadow/state.go
@@ -86,6 +86,21 @@ type thingDelta struct {
 	Timestamp int            `json:"timestamp,omitempty"`
 }
 
+func newThingDocument() *ThingDocument {
+	return &ThingDocument{
+		State: ThingState{
+			Desired:  NestedState{},
+			Reported: NestedState{},
+			Delta:    NestedState{},
+		},
+		Metadata: ThingStateMetadata{
+			Desired:  NestedMetadata{},
+			Reported: NestedMetadata{},
+			Delta:    NestedMetadata{},
+		},
+	}
+}
+
 func (s *ThingDocument) update(state *thingDocumentRaw) error {
 	if s.Version > state.Version {
 		// Received an old version; just ignore it.


### PR DESCRIPTION
Fixes #235 
Currently getAccepted updates Reported, Accepted or Delta to nil when they are empty on Shadow, so that panic due to nil pointer reference occurs [here](https://github.com/seqsense/aws-iot-device-sdk-go/blob/407d38db980ed84290bda35c60e52df3f5e98c0a/shadow/shadow.go#L133) on updateAccepted.