### PR TITLE
Migrate golint to revive

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,19 +7,14 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Go
-        uses: actions/setup-go@v3
-      - name: Install golint
-        run: |
-          go get golang.org/x/lint/golint
-          go install golang.org/x/lint/golint
-          echo $(go env GOPATH)/bin >> ${GITHUB_PATH}
       - name: Lint
-        run: |
-          golint ./... | sed 's/^\([^:]\+\):\([0-9]\+\):\([0-9]\+\): \(.*\)$/::warning file=\1,line=\2,col=\3::\4/'
+        uses: morphy2k/revive-action@v2


### PR DESCRIPTION
Golint is deprecated and the repository has been archived.
Revive is a drop-in replacement of golint.