### PR TITLE
Use actions token to deploy tunnel server image

### DIFF
--- a/.github/workflows/tunnel-server.yaml
+++ b/.github/workflows/tunnel-server.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CONTAINER_REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to GitHub Container Registry
         if: startsWith(github.ref, 'refs/tags')
         run: |


### PR DESCRIPTION
Instead of the personal access token.
Write access is allowed by the container registry setting.