### PR TITLE
Do not ignore renovate update under examples

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,5 +31,6 @@
             "automerge": true
         }
     ],
+    "ignorePaths": [],
     "timezone": "Asia/Tokyo"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -32,5 +32,8 @@
         }
     ],
     "ignorePaths": [],
+    "ignoreDeps": [
+        "github.com/seqsense/aws-iot-device-sdk-go/v6"
+    ],
     "timezone": "Asia/Tokyo"
 }


### PR DESCRIPTION
config:base preset ignores examples directory by default

https://docs.renovatebot.com/presets-config/#configbase
https://docs.renovatebot.com/presets-default/#ignoremodulesandtests