### PR TITLE
Migrate aws-iot-device-sdk-go/examples code from mitchellh/mapstructure to go-viper/mapstructure 4149

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -6,7 +6,7 @@ replace github.com/seqsense/aws-iot-device-sdk-go/v6 => ../
 
 require (
 	github.com/at-wat/mqtt-go v0.19.6
-	github.com/mitchellh/mapstructure v1.5.0
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/seqsense/aws-iot-device-sdk-go/v6 v6.0.0-00010101000000-000000000000
 )
 

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -26,10 +26,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.38.6 h1:p3jIvqYwUZgu/XYeI48bJxOhvm47
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.6/go.mod h1:WtKK+ppze5yKPkZ0XwqIVWD4beCwv056ZbPQNoeHqM8=
 github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
 github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
 golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/examples/shadow/main.go
+++ b/examples/shadow/main.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/at-wat/mqtt-go"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	awsiotdev "github.com/seqsense/aws-iot-device-sdk-go/v6"
 	"github.com/seqsense/aws-iot-device-sdk-go/v6/shadow"
 )
@@ -129,7 +129,7 @@ func main() {
 	fmt.Printf("document:%s", prettyDump(doc))
 
 	// Document stores thing state as map[string]interface{}.
-	// You may want to use github.com/mitchellh/mapstructure to
+	// You may want to use github.com/go-viper/mapstructure/v2 to
 	// converts state to the given struct.
 	var typedState sampleState
 	if err := mapstructure.Decode(doc.State.Desired, &typedState); err != nil {


### PR DESCRIPTION
issue：
・https://github.com/seqsense/sq-cloud-issues/issues/4149

検証：
・本コード上ではexamplesでのみmitchellh/mapstructureが使用されている。その部分で使われているmapstructure.Decode の使用方法をテストコードで再現・検証した。変更の前後で同じ結果が得られることを確認した

