### PR TITLE
Drop Go 1.23 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.23"
           - "1.24"
           - "1.25"
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seqsense/aws-iot-device-sdk-go/v6
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/at-wat/mqtt-go v0.19.6


### PR DESCRIPTION
## Summary

Some golang.org/x modules have dropped support for Go 1.23, which prevents us from updating these modules. Therefore, we are dropping Go 1.23 support.

## Changes

- Updated minimum Go version to 1.24.0 in go.mod
- Removed Go 1.23 from the CI test matrix